### PR TITLE
Update PIRCS.cpp

### DIFF
--- a/pircs_library/PIRCS.cpp
+++ b/pircs_library/PIRCS.cpp
@@ -264,7 +264,7 @@ uint16_t fill_JSON_buffer_with_ack(Acknowledgement *ack,
                                     char *buff,
                                     uint16_t size) {
   uint16_t rval = sprintf(buff,
-                          "{\"ack\":\"%c\",\"err\":\"%d\",\"com\":\"%c\",\"par\":\"%c\",\"int\":\"%c\",\"mod\":\"%c\",\"val\":%d}",
+                          "{\"ack\":\"%c\",\"err\":\"%d\",\"com\":\"%c\",\"par\":\"%c\",\"int\":\"%c\",\"mod\":\"%c\",\"val\":%ld}",
                           ack->ack,
                           ack->err,
                      ack->command,

--- a/pircs_library/PIRCS.cpp
+++ b/pircs_library/PIRCS.cpp
@@ -127,7 +127,7 @@ SetCommand get_set_command_from_buffer(uint8_t* buff,uint16_t blim) {
 
 uint16_t fill_JSON_buffer_set_command(SetCommand* s,char* buff,uint16_t blim) {
   uint16_t rval = sprintf(buff,
-  "{\"com\":\"%c\",\"par\":\"%c\",\"int\":\"%c\",\"mod\":\"%c\",\"val\":%d}",
+  "{\"com\":\"%c\",\"par\":\"%c\",\"int\":\"%c\",\"mod\":\"%c\",\"val\":%ld}",
                      s->command,
                      s->parameter,
                      s->interpretation,


### PR DESCRIPTION
To format a long int using sprintf, you can use the following format specifier: %ld

This throws an error because the type is int32_t but sprintf typecasts it as int